### PR TITLE
[backport] Add CI scripts and build config

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -1,0 +1,18 @@
+source ~/.bashrc
+GO_VERSION=${GO_VERSION:-1.19}
+
+configure_go() {
+  if [ -n "${USE_SYSTEM_GO:-}" ] ; then
+    echo "\$USE_SYSTEM_GO set, using system go instead of gimme"
+    return 0
+  else
+    which gimme > /dev/null || (echo "error: missing required command 'gimme'" && exit 1)
+    eval "$(GIMME_GO_VERSION=${GO_VERSION} gimme)"
+  fi
+  which go
+  go version
+}
+
+configure_go
+
+KUBE_BUILD_PLATFORMS=linux/amd64 make all WHAT=cmd/kubelet GOFLAGS=-v


### PR DESCRIPTION
Add basic CI script and build configuration.
The TC build config can be found [here](https://teamcity.platform9.horse/buildConfiguration/Pf9project_Platform9ComponentsForKubernetes_EmpKubelet?mode=builds).